### PR TITLE
Fix typo in protocol for cc.columbia.edu mirror

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,3 @@
 hadoop_type_of_node: slave
 hadoop_home: /opt/hadoop-1.X
-mirrors: [ "htttp://mirror.cc.columbia.edu/pub/software/apache/hadoop/core/hadoop-1.2.1/", "http://ftp.cixug.es/apache/hadoop/core/hadoop-1.2.1/","http://www-eu.apache.org/dist/hadoop/core/hadoop-1.2.1/","http://ftp.osuosl.org/pub/apache/hadoop/core/hadoop-1.2.1/" ]
+mirrors: [ "http://mirror.cc.columbia.edu/pub/software/apache/hadoop/core/hadoop-1.2.1/", "http://ftp.cixug.es/apache/hadoop/core/hadoop-1.2.1/","http://www-eu.apache.org/dist/hadoop/core/hadoop-1.2.1/","http://ftp.osuosl.org/pub/apache/hadoop/core/hadoop-1.2.1/" ]


### PR DESCRIPTION
The mirror url for cc.columbia.edu had a protocol of 'htttp' :-)
